### PR TITLE
Add building attribute support

### DIFF
--- a/MQTTSyncClientConfigurator/form.json
+++ b/MQTTSyncClientConfigurator/form.json
@@ -34,6 +34,11 @@
                     "width": "400px"
                 },
                 {
+                    "caption": "Building",
+                    "name": "Building",
+                    "width": "200px"
+                },
+                {
                     "caption": "Object Type",
                     "name": "ObjectType",
                     "width": "auto"

--- a/MQTTSyncClientConfigurator/module.php
+++ b/MQTTSyncClientConfigurator/module.php
@@ -29,6 +29,7 @@ class MQTTSyncClientConfigurator extends IPSModule
                 'ObjectID'      => $Device->ObjectID,
                 'ObjectName'    => $Device->ObjectName,
                 'MQTTTopic'     => $Device->MQTTTopic,
+                'Building'      => property_exists($Device, 'Building') ? $Device->Building : '',
                 'ObjectType'    => $Device->ObjectType,
                 'name'          => $Device->ObjectName . ' (' . $Device->MQTTTopic . ')',
                 'instanceID'    => $instanceID

--- a/MQTTSyncServer/README.md
+++ b/MQTTSyncServer/README.md
@@ -15,7 +15,7 @@
 
 * Das MQTT Topic gibt an, unter welchem Group Topic die zu synchronisierenden Daten versendet werden.
 * In der Liste können die Objekte angegeben werden, welche mit dem Slave System synchronisiert werden sollen.
-    * Es wird die ObjektID und das MQTT Topic hinterlegt.
+* Es wird die ObjektID, das MQTT Topic und optional ein Building hinterlegt.
     * Als Objekt können Variablen oder komplette Instanzen hinterlegt werden
 
 ## 3. Spenden

--- a/MQTTSyncServer/form.json
+++ b/MQTTSyncServer/form.json
@@ -39,6 +39,15 @@
                     "edit": {
                         "type": "ValidationTextBox"
                     }
+                },
+                {
+                    "caption": "Building",
+                    "name": "Building",
+                    "width": "200px",
+                    "add": "",
+                    "edit": {
+                        "type": "ValidationTextBox"
+                    }
                 }
             ],
             "values": []

--- a/MQTTSyncServer/module.php
+++ b/MQTTSyncServer/module.php
@@ -81,6 +81,7 @@ class MQTTSyncServer extends IPSModule
                                 $Instanz[$i]['ID'] = $tmpObject['ObjectID'];
                                 $Instanz[$i]['Name'] = $tmpObject['ObjectName'];
                                 $Instanz[$i]['ObjectIdent'] = $tmpObject['ObjectIdent'];
+                                $Instanz[$i]['Building'] = property_exists($Device, 'Building') ? $Device->Building : '';
                                 $Instanz[$i]['VariableTyp'] = IPS_GetVariable($tmpObject['ObjectID'])['VariableType'];
                                 $Instanz[$i]['VariableAction'] = IPS_GetVariable($tmpObject['ObjectID'])['VariableAction'];
                                 $Instanz[$i]['VariableCustomAction'] = IPS_GetVariable($tmpObject['ObjectID'])['VariableAction'];
@@ -95,6 +96,7 @@ class MQTTSyncServer extends IPSModule
                         $Instanz[0]['ID'] = $Object['ObjectID'];
                         $Instanz[0]['Name'] = $Object['ObjectName'];
                         $Instanz[0]['ObjectIdent'] = $Object['ObjectIdent'];
+                        $Instanz[0]['Building'] = property_exists($Device, 'Building') ? $Device->Building : '';
                         $Instanz[0]['VariableTyp'] = IPS_GetVariable($Object['ObjectID'])['VariableType'];
                         $Instanz[0]['VariableAction'] = IPS_GetVariable($Object['ObjectID'])['VariableAction'];
                         $Instanz[0]['VariableCustomAction'] = IPS_GetVariable($Object['ObjectID'])['VariableCustomAction'];
@@ -224,6 +226,11 @@ class MQTTSyncServer extends IPSModule
             $tmpConfiguration['ObjectID'] = $Device->ObjectID;
             $tmpConfiguration['ObjectName'] = IPS_GetObject($Device->ObjectID)['ObjectName'];
             $tmpConfiguration['MQTTTopic'] = $Device->MQTTTopic;
+            if (property_exists($Device, 'Building')) {
+                $tmpConfiguration['Building'] = $Device->Building;
+            } else {
+                $tmpConfiguration['Building'] = '';
+            }
             $tmpConfiguration['ObjectType'] = IPS_GetObject($Device->ObjectID)['ObjectType'];
             array_push($Configuration, $tmpConfiguration);
         }
@@ -312,6 +319,7 @@ class MQTTSyncServer extends IPSModule
                         $Instanz[$i]['ID'] = $tmpObject['ObjectID'];
                         $Instanz[$i]['Name'] = $tmpObject['ObjectName'];
                         $Instanz[$i]['ObjectIdent'] = $tmpObject['ObjectIdent'];
+                        $Instanz[$i]['Building'] = property_exists($Device, 'Building') ? $Device->Building : '';
                         $Instanz[$i]['VariableTyp'] = IPS_GetVariable($tmpObject['ObjectID'])['VariableType'];
                         $Instanz[$i]['VariableAction'] = IPS_GetVariable($tmpObject['ObjectID'])['VariableAction'];
                         $Instanz[$i]['VariableCustomAction'] = IPS_GetVariable($tmpObject['ObjectID'])['VariableAction'];
@@ -326,6 +334,7 @@ class MQTTSyncServer extends IPSModule
                 $Instanz[0]['ID'] = $Object['ObjectID'];
                 $Instanz[0]['Name'] = $Object['ObjectName'];
                 $Instanz[0]['ObjectIdent'] = $Object['ObjectIdent'];
+                $Instanz[0]['Building'] = property_exists($Device, 'Building') ? $Device->Building : '';
                 $Instanz[0]['VariableTyp'] = IPS_GetVariable($Object['ObjectID'])['VariableType'];
                 $Instanz[0]['VariableAction'] = IPS_GetVariable($Object['ObjectID'])['VariableAction'];
                 $Instanz[0]['VariableCustomAction'] = IPS_GetVariable($Object['ObjectID'])['VariableCustomAction'];

--- a/library.json
+++ b/library.json
@@ -3,7 +3,7 @@
     "author": "Kai Schnittcher",
     "name": "MQTTSync",
     "url": "https://github.com/Schnittcher/IPS-MQTTSync",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "build": 0,
     "date": 0
 }


### PR DESCRIPTION
## Summary
- allow specifying Building per device
- include Building in configuration payloads and variable updates
- show Building column in server and client configurator UIs
- document Building field and bump library version

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685947c9de0c832596b69ec5689ea61d